### PR TITLE
Auto config

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -161,7 +161,6 @@ plug-install -params ..1 %{
                     cd $(eval echo $kak_opt_plug_install_dir) && $git >/dev/null 2>&1
                     printf %s\\n "evaluate-commands -client $kak_client echo -debug 'installed ${plugin##*/}'" | kak -p ${kak_session}
                     printf %s\\n "evaluate-commands -client $kak_client plug $plugin" | kak -p ${kak_session}
-                    printf %s\\n "evaluate-commands -client $kak_client plug-configure $plugin" | kak -p ${kak_session}
                     exit
                 ) &
             fi
@@ -181,7 +180,6 @@ plug-install -params ..1 %{
                         printf %s\\n "evaluate-commands -client $kak_client echo -debug 'installed ${plugin##*/}'" | kak -p ${kak_session}
                         printf %s\\n "evaluate-commands -client $kak_client plug-eval-hooks $plugin" | kak -p ${kak_session}
                         printf %s\\n "evaluate-commands -client $kak_client plug $plugin" | kak -p ${kak_session}
-                        printf %s\\n "evaluate-commands -client $kak_client plug-configure $plugin" | kak -p ${kak_session}
                     ) &
                 fi
                 jobs > $jobs; active=$(wc -l < $jobs)


### PR DESCRIPTION
**plug.kak** now automatically loads plugins after installation.
Externalized configuration process to separate command, which enables automatic configuration of plugin right after installation. No need to reload Kakoune after installation of a plugin.

Also updated some regexps for syntax highlighting.