### PR TITLE
feat(plug.kak): update define-command shell options

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -68,7 +68,7 @@ hook  global WinSetOption filetype=(?!kak).* %{ try %{
 define-command -override -docstring \
 "plug <plugin> [<branch>] [<noload>] [<configurations>]: load <plugin> from ""%opt{plug_install_dir}""
 " \
-plug -params 1.. -shell-candidates %{ ls -1 $(eval echo $kak_opt_plug_install_dir) } %{
+plug -params 1.. -shell-script-candidates %{ ls -1 $(eval echo $kak_opt_plug_install_dir) } %{
     set-option -add global plug_plugins "%arg{1} "
     evaluate-commands %sh{
         start=$(expr $(date +%s%N) / 10000000)
@@ -198,7 +198,7 @@ plug-install -params ..1 %{
 define-command -override -docstring \
 "plug-update [<plugin>]: Update plugin.
 If <plugin> ommited all installed plugins are updated" \
-plug-update -params ..1 -shell-candidates %{ echo $kak_opt_plug_plugins | tr ' ' '\n' } %{
+plug-update -params ..1 -shell-script-candidates %{ echo $kak_opt_plug_plugins | tr ' ' '\n' } %{
     evaluate-commands %sh{ (
         plugin=$1
         if [ -d $(eval echo "$kak_opt_plug_install_dir/.plug.kaklock") ]; then
@@ -248,7 +248,7 @@ plug-update -params ..1 -shell-candidates %{ echo $kak_opt_plug_plugins | tr ' '
 define-command -override -docstring \
 "plug-delete [<plugin>]: delete <plugin>.
 If <plugin> ommited deletes all plugins that are not presented in configuration files" \
-plug-clean -params ..1 -shell-candidates %{ ls -1 $(eval echo $kak_opt_plug_install_dir) } %{
+plug-clean -params ..1 -shell-script-candidates %{ ls -1 $(eval echo $kak_opt_plug_install_dir) } %{
     nop %sh{ (
         plugin=$1
         if [ -d $(eval echo "$kak_opt_plug_install_dir/.plug.kaklock") ]; then


### PR DESCRIPTION
The new Kakoune update (v2018.10.27) seems to have made changes to the `define-command` option set, thus breaking the plugin manager.  Made the appropriate updates to **plug.kak**.

[**EDIT**]
I just realized there is a *dev* branch.  Should I have issued a pull request there instead?

[**EDIT2**]
I see that changes have been made on the dev branch