### PR TITLE
remove shallow cloning

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -151,9 +151,9 @@ plug-install -params ..1 %{
         if [ ! -z $plugin ]; then
             case $plugin in
                 http*|git*)
-                    git="git clone $plugin --depth 1" ;;
+                    git="git clone $plugin" ;;
                 *)
-                    git="git clone $kak_opt_plug_git_domain/$plugin --depth 1" ;;
+                    git="git clone $kak_opt_plug_git_domain/$plugin" ;;
             esac
             if [ ! -d $(eval echo $kak_opt_plug_install_dir/"${plugin##*/}") ]; then
                 printf %s\\n "evaluate-commands -client $kak_client echo -markup '{Information}Installing $plugin'" | kak -p ${kak_session}
@@ -170,9 +170,9 @@ plug-install -params ..1 %{
             for plugin in $kak_opt_plug_plugins; do
                 case $plugin in
                     http*|git*)
-                        git="git clone $plugin --depth 1" ;;
+                        git="git clone $plugin" ;;
                     *)
-                        git="git clone $kak_opt_plug_git_domain/$plugin --depth 1" ;;
+                        git="git clone $kak_opt_plug_git_domain/$plugin" ;;
                 esac
                 if [ ! -d $(eval echo $kak_opt_plug_install_dir/"${plugin##*/}") ]; then
                     (


### PR DESCRIPTION
Shallow cloning is unnecessary (plugins are small) and it breaks checkout functionality.  

Basically you can't checkout commits that does not exist on your disk.

Not sure if I'm sending PR against correct branch.