### PR TITLE
plug-list, FIFO

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -194,10 +194,16 @@ plug-install -params ..1 %{
 
         if [ -n "$plugin" ]; then
             plugin_list=$plugin
-            printf "%s\n" "evaluate-commands -client $kak_client echo -markup '{Information}Installing $plugin'" | kak -p ${kak_session}
+            printf "%s\n" "evaluate-commands -buffer *plug* %{
+                try %{
+                    execute-keys /${plugin}<ret>
+                } catch %{
+                    execute-keys gjO${plugin}:<space>Not<space>installed<esc>
+                }
+            }" | kak -p ${kak_session}
+            sleep 0.2
         else
             plugin_list=$kak_opt_plug_plugins
-            printf "%s\n" "evaluate-commands -client $kak_client echo -markup '{Information}Installing plugins in background'" | kak -p ${kak_session}
         fi
 
         for plugin in $plugin_list; do
@@ -440,8 +446,8 @@ plug-fifo-operate %{ evaluate-commands -save-regs t %{
 
 define-command -override \
 -docstring "plug-update-fifo <plugin> <message>" \
-plug-update-fifo -params 2 %{ evaluate-commands -buffer *plug* -save-regs "/""" %{
+plug-update-fifo -params 2 %{ evaluate-commands -buffer *plug* -save-regs "/""" %{ try %{
     set-register / "%arg{1}: "
     set-register dquote %arg{2}
     execute-keys /<ret>lGlR
-}}
+}}}

--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -378,14 +378,10 @@ plug-list %{ evaluate-commands -save-regs t %{
                 if [ -d "$kak_opt_plug_install_dir/${1##*/}" ]; then
                     (
                         cd $kak_opt_plug_install_dir/${1##*/}
-                        LOCAL=$(git rev-parse @{0})
-                        REMOTE=$(git rev-parse @{u})
-                        if [ $LOCAL = $REMOTE ]; then
+                        if git diff --quiet remotes/origin/HEAD; then
                             printf "%s: %s\n" $1 "Up to date" >> ${output}
-                        elif [ $LOCAL = $BASE ]; then
-                            printf "%s: %s\n" $1 "Update available" >> ${output}
                         else
-                            printf "%s: %s\n" $1 "Installed" >> ${output}
+                            printf "%s: %s\n" $1 "Update available" >> ${output}
                         fi
                     )
                 else
@@ -397,7 +393,7 @@ plug-list %{ evaluate-commands -save-regs t %{
     }
     try %{ delete-buffer *plug* }
     edit! -fifo %reg{t} *plug*
-    hook -always -once buffer BufCloseFifo .* %{ nop %sh{ rm -rf "${kak_reg_t##*/}" }}
+    hook -always -once buffer BufCloseFifo .* %{ nop %sh{ rm -rf "${kak_reg_t##*/}" } }
     map buffer normal "<ret>" ":<space>plug-fifo-operate<ret>"
     execute-keys -draft ged
 }}

--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -161,7 +161,7 @@ plug-install -params ..1 %{
         jobs=$(mktemp ${TMPDIR:-/tmp}/jobs.XXXXXX)
 
         if [ -d $(eval echo "$kak_opt_plug_install_dir/.plug.kaklock") ]; then
-            printf %s\\n "evaluate-commands -client $kak_client echo -markup '{Information}.plug.kaklock is present. Waiting...'" | kak -p ${kak_session}
+            printf "%s\n" "evaluate-commands -client $kak_client echo -markup '{Information}.plug.kaklock is present. Waiting...'" | kak -p ${kak_session}
         fi
 
         while ! mkdir $(eval echo "$kak_opt_plug_install_dir/.plug.kaklock") 2>/dev/null; do sleep 1; done
@@ -176,7 +176,7 @@ plug-install -params ..1 %{
             printf "%s\n" "evaluate-commands -client $kak_client echo -markup '{Information}Installing $plugin'" | kak -p ${kak_session}
         else
             plugin_list=$kak_opt_plug_plugins
-            printf %s\\n "evaluate-commands -client $kak_client echo -markup '{Information}Installing plugins in background'" | kak -p ${kak_session}
+            printf "%s\n" "evaluate-commands -client $kak_client echo -markup '{Information}Installing plugins in background'" | kak -p ${kak_session}
         fi
 
         for plugin in $plugin_list; do
@@ -189,9 +189,9 @@ plug-install -params ..1 %{
             if [ ! -d $(eval echo $kak_opt_plug_install_dir/"${plugin##*/}") ]; then
                 (
                     cd $(eval echo $kak_opt_plug_install_dir) && $git >/dev/null 2>&1
-                    printf %s\\n "evaluate-commands -client $kak_client echo -debug 'installed ${plugin##*/}'" | kak -p ${kak_session}
-                    printf %s\\n "evaluate-commands -client $kak_client plug-eval-hooks $plugin" | kak -p ${kak_session}
-                    printf %s\\n "evaluate-commands -client $kak_client plug $plugin" | kak -p ${kak_session}
+                    printf "%s\n" "evaluate-commands -client $kak_client echo -debug 'installed ${plugin##*/}'" | kak -p ${kak_session}
+                    printf "%s\n" "evaluate-commands -client $kak_client plug-eval-hooks $plugin" | kak -p ${kak_session}
+                    printf "%s\n" "evaluate-commands -client $kak_client plug $plugin" | kak -p ${kak_session}
                 ) &
             fi
             jobs > $jobs; active=$(wc -l < $jobs)
@@ -214,7 +214,7 @@ plug-update -params ..1 -shell-script-candidates %{ echo $kak_opt_plug_plugins |
         jobs=$(mktemp ${TMPDIR:-/tmp}/jobs.XXXXXX)
 
         if [ -d $(eval echo "$kak_opt_plug_install_dir/.plug.kaklock") ]; then
-            printf %s\\n "evaluate-commands -client $kak_client echo -markup '{Information}.plug.kaklock is present. Waiting...'" | kak -p ${kak_session}
+            printf "%s\n" "evaluate-commands -client $kak_client echo -markup '{Information}.plug.kaklock is present. Waiting...'" | kak -p ${kak_session}
         fi
 
         while ! mkdir $(eval echo "$kak_opt_plug_install_dir/.plug.kaklock") 2>/dev/null; do sleep 1; done
@@ -231,8 +231,8 @@ plug-update -params ..1 -shell-script-candidates %{ echo $kak_opt_plug_plugins |
             (
                 cd $(eval echo $kak_opt_plug_install_dir/"${plugin##*/}") && rev=$(git rev-parse HEAD) && git pull -q
                 if [ $rev != $(git rev-parse HEAD) ]; then
-                    printf %s\\n "evaluate-commands -client $kak_client plug-eval-hooks $plugin" | kak -p ${kak_session}
-                    printf %s\\n "evaluate-commands -client $kak_client echo -debug 'updated ${plugin##*/}'" | kak -p ${kak_session}
+                    printf "%s\n" "evaluate-commands -client $kak_client plug-eval-hooks $plugin" | kak -p ${kak_session}
+                    printf "%s\n" "evaluate-commands -client $kak_client echo -debug 'updated ${plugin##*/}'" | kak -p ${kak_session}
                 fi
             ) &
             jobs > $jobs; active=$(wc -l < $jobs)
@@ -243,7 +243,7 @@ plug-update -params ..1 -shell-script-candidates %{ echo $kak_opt_plug_plugins |
         done
         rm -rf $jobs
         wait
-        printf %s\\n "evaluate-commands -client $kak_client echo -markup '{Information}Done updating plugins'" | kak -p ${kak_session}
+        printf "%s\n" "evaluate-commands -client $kak_client echo -markup '{Information}Done updating plugins'" | kak -p ${kak_session}
     ) > /dev/null 2>&1 < /dev/null & }
 }
 
@@ -255,7 +255,7 @@ plug-clean -params ..1 -shell-script-candidates %{ ls -1 $(eval echo $kak_opt_pl
         plugin=$1
 
         if [ -d $(eval echo "$kak_opt_plug_install_dir/.plug.kaklock") ]; then
-            printf %s\\n "evaluate-commands -client $kak_client echo -markup '{Information}.plug.kaklock is present. Waiting...'" | kak -p ${kak_session}
+            printf "%s\n" "evaluate-commands -client $kak_client echo -markup '{Information}.plug.kaklock is present. Waiting...'" | kak -p ${kak_session}
         fi
 
         while ! mkdir $(eval echo "$kak_opt_plug_install_dir/.plug.kaklock") 2>/dev/null; do sleep 1; done
@@ -264,9 +264,9 @@ plug-clean -params ..1 -shell-script-candidates %{ ls -1 $(eval echo $kak_opt_pl
         if [ -n "$plugin" ]; then
             if [ -d $(eval echo $kak_opt_plug_install_dir/"${plugin##*/}") ]; then
                 (cd $(eval echo $kak_opt_plug_install_dir) && rm -rf "${plugin##*/}")
-                printf %s\\n "evaluate-commands -client $kak_client echo -debug 'removed ${plugin##*/}'" | kak -p ${kak_session}
+                printf "%s\n" "evaluate-commands -client $kak_client echo -debug 'removed ${plugin##*/}'" | kak -p ${kak_session}
             else
-                printf %s\\n "evaluate-commands -client $kak_client echo -markup %{{Error}No such plugin '$plugin'}" | kak -p ${kak_session}
+                printf "%s\n" "evaluate-commands -client $kak_client echo -markup %{{Error}No such plugin '$plugin'}" | kak -p ${kak_session}
                 exit
             fi
         else
@@ -279,7 +279,7 @@ plug-clean -params ..1 -shell-script-candidates %{ ls -1 $(eval echo $kak_opt_pl
             done
             for plugin in $plugins_to_remove; do
                 rm -rf $plugin
-                printf %s\\n "evaluate-commands -client $kak_client echo -debug 'removed ${plugin##*/}'" | kak -p ${kak_session}
+                printf "%s\n" "evaluate-commands -client $kak_client echo -debug 'removed ${plugin##*/}'" | kak -p ${kak_session}
             done
         fi
     ) > /dev/null 2>&1 < /dev/null & }
@@ -371,7 +371,12 @@ plug-list %{ evaluate-commands -save-regs t %{
         printf "%s" "${output}"
         (   eval "set -- $kak_opt_plug_plugins"
             while [ $# -gt 0 ]; do
-                printf "%s\n" $1 >> ${output}
+                if [ -d $(eval echo $kak_opt_plug_install_dir/"${1##*/}") ]; then
+                    status="Installed"
+                else
+                    status="Not installed"
+                fi
+                printf "%s: %s\n" $1 "$status" >> ${output}
                 shift
             done
         ) > /dev/null 2>&1 < /dev/null &
@@ -385,17 +390,14 @@ plug-list %{ evaluate-commands -save-regs t %{
 define-command -override \
 -docstring "operate on *plug* buffer contents based on current cursor position" \
 plug-fifo-operate %{ evaluate-commands -save-regs t %{
-    execute-keys -save-regs '' "<a-i><a-w>"
+    execute-keys -save-regs '' "<a-h><a-l>"
     set-register t %val{selection}
     evaluate-commands %sh{
-        selection=$kak_reg_t
-        case $arg in
-            */*)
-            printf "%s\n" "plug-update $selection" ;;
-            log)
-                ;;
-            *)
-                ;;
-        esac
+        plugin="${kak_reg_t%:*}"
+        if [ -d $(eval echo "$kak_opt_plug_install_dir/${plugin##*/}") ]; then
+            printf "%s\n" "plug-update $plugin'"
+        else
+            printf "%s\n" "plug-install $plugin'"
+        fi
     }
 }}

--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -253,7 +253,6 @@ plug-update -params ..1 -shell-script-candidates %{ echo $kak_opt_plug_plugins |
                 cd "$kak_opt_plug_install_dir/${plugin##*/}" && rev=$(git rev-parse HEAD) && git pull -q
                 if [ $rev != $(git rev-parse HEAD) ]; then
                     printf "%s\n" "evaluate-commands -client $kak_client plug-eval-hooks $plugin $fifo" | kak -p ${kak_session}
-                else
                 fi
             ) &
             jobs > $jobs; active=$(wc -l < $jobs)

--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -70,7 +70,7 @@ hook global WinSetOption filetype=kak %{ try %{
 add-highlighter shared/plug group
 add-highlighter shared/plug/done          regex ^([^:]+)(:)\h+(Up\h+to\h+date|Done)$           1:Default 2:keyword 3:string
 add-highlighter shared/plug/update        regex ^([^:]+)(:)\h+(Update\h+available)$            1:Default 2:keyword 3:type
-add-highlighter shared/plug/not_installed regex ^([^:]+)(:)\h+(Not\h+Installed)$               1:Default 2:keyword 3:Error
+add-highlighter shared/plug/not_installed regex ^([^:]+)(:)\h+(Not\h+installed)$               1:Default 2:keyword 3:Error
 add-highlighter shared/plug/updating      regex ^([^:]+)(:)\h+(Installing|Updating)$           1:Default 2:keyword 3:type
 add-highlighter shared/plug/working       regex ^([^:]+)(:)\h+(Running\h+post-update\h+hooks)$ 1:Default 2:keyword 3:attribute
 

--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -70,7 +70,7 @@ hook global WinSetOption filetype=kak %{ try %{
 add-highlighter shared/plug group
 add-highlighter shared/plug/done          regex ^([^:]+)(:)\h+(Up\h+to\h+date|Done)$           1:Default 2:keyword 3:string
 add-highlighter shared/plug/update        regex ^([^:]+)(:)\h+(Update\h+available)$            1:Default 2:keyword 3:type
-add-highlighter shared/plug/not_installed regex ^([^:]+)(:)\h+(Not\h+Installed)$               1:Default 2:keyword 3:error
+add-highlighter shared/plug/not_installed regex ^([^:]+)(:)\h+(Not\h+Installed)$               1:Default 2:keyword 3:Error
 add-highlighter shared/plug/updating      regex ^([^:]+)(:)\h+(Installing|Updating)$           1:Default 2:keyword 3:type
 add-highlighter shared/plug/working       regex ^([^:]+)(:)\h+(Running\h+post-update\h+hooks)$ 1:Default 2:keyword 3:attribute
 


### PR DESCRIPTION
This PR adds new command `plug-list` that was requested in #26. It can be used to check what plugins are currently installed and loaded, it also checks if update is available.

From now on plug.kak uses FIFO (#10) to display it's info. This also should fix #36 since now user can observe the status of plug in the `*plug*` buffer