### PR TITLE
fix 69 remove obsolete require-module

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -60,9 +60,6 @@ declare-option -hidden -docstring \
 "List of post update/install hooks to be executed" \
 str-list plug_domains
 
-# since we want to add highlighters to kak filetype we need to require kak module
-require-module kak
-
 # kakrc highlighters
 try %[
     add-highlighter shared/kakrc/code/plug_keywords   regex (^|\h)\b(plug|do|config|load|domain|defer)\b(\h+)?((?=")|(?=')|(?=%)|(?=\w)) 0:keyword


### PR DESCRIPTION
Fixing this error I got after installing plug.kak and sourcing it according to the README

error while parsing kakrc:
    1:1: 'source' 5:853: 'evaluate-commands' 98:14233: 'source' 1:1: 'source' no such command: 'require-module'

Thank you for making this.
