### PR TITLE
plug.sh: allow file:// URLs

### DIFF
--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -164,7 +164,7 @@ plug_install () {
                     plug_fifo_update "${plugin_name}" "Installing"
                     cd "${kak_opt_plug_install_dir}" || exit
                     case ${plugin} in
-                        (http*|git*)
+                        (http*|git*|file*)
                             git clone --recurse-submodules "${plugin}" "$plugin_name" >> "$plugin_log" 2>&1 ;;
                         (*)
                             git clone --recurse-submodules "$git_domain/$plugin" "$plugin_name" >> "$plugin_log" 2>&1 ;;


### PR DESCRIPTION
6-byte changeset. Allows to refer to local git repos without, seemingly, and so far, any complications as in the case of load-path (which I haven't been able to get to work for my purposes)