### PR TITLE
fix: #85

### DIFF
--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -164,7 +164,7 @@ plug_install () {
                     plug_fifo_update "${plugin_name}" "Installing"
                     cd "${kak_opt_plug_install_dir}" || exit
                     case ${plugin} in
-                        (http*|git*|file*)
+                        (https://*|http://*|git@*|file://*)
                             git clone --recurse-submodules "${plugin}" "$plugin_name" >> "$plugin_log" 2>&1 ;;
                         (*)
                             git clone --recurse-submodules "$git_domain/$plugin" "$plugin_name" >> "$plugin_log" 2>&1 ;;

--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -164,7 +164,7 @@ plug_install () {
                     plug_fifo_update "${plugin_name}" "Installing"
                     cd "${kak_opt_plug_install_dir}" || exit
                     case ${plugin} in
-                        (https://*|http://*|git@*|file://*)
+                        (https://*|http://*|git@*|file://*|ext::*)
                             git clone --recurse-submodules "${plugin}" "$plugin_name" >> "$plugin_log" 2>&1 ;;
                         (*)
                             git clone --recurse-submodules "$git_domain/$plugin" "$plugin_name" >> "$plugin_log" 2>&1 ;;


### PR DESCRIPTION
This adds more specific checks for URL schemes, which should prevent from parsing the following plugins as urls: `git-guru/kakplug`, `httpclient/kakadapter`