### PR TITLE
Avoid false positives in kakrc keyword highlighting

### DIFF
--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -58,8 +58,8 @@ try %@
     require-module kak
 
     try %$
-        add-highlighter shared/kakrc/code/plug_keywords   regex \b(plug|do|config|domain|defer|demand|load-path|branch|tag|commit)\b 0:keyword
-        add-highlighter shared/kakrc/code/plug_attributes regex \b(noload|ensure|theme)\b 0:attribute
+        add-highlighter shared/kakrc/code/plug_keywords   regex '\b(plug|do|config|domain|defer|demand|load-path|branch|tag|commit)(?=[ \t])' 0:keyword
+        add-highlighter shared/kakrc/code/plug_attributes regex '(?<=[ \t])(noload|ensure|theme)\b' 0:attribute
         add-highlighter shared/kakrc/plug_post_hooks1     region -recurse '\{' '\bdo\K\h+%\{' '\}' ref sh
         add-highlighter shared/kakrc/plug_post_hooks2     region -recurse '\[' '\bdo\K\h+%\[' '\]' ref sh
         add-highlighter shared/kakrc/plug_post_hooks3     region -recurse '\(' '\bdo\K\h+%\(' '\)' ref sh


### PR DESCRIPTION
For example for a command "lsp-did-change-config" in kakrc, the
"config" suffix was highlighted, since "-" is not a word character
for \w.

As far as I can tell, those keywords always have at least one guarding
space except in contrived cases.