### PR TITLE
plug.sh: jobs file: create late, remove early

### DIFF
--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -116,7 +116,6 @@ plug_install () {
         plugin="${1%%.git}"
         noload=$2
         plugin_name="${plugin##*/}"
-        jobs=$(mktemp "${TMPDIR:-/tmp}"/plug.kak.jobs.XXXXXX)
         build_dir="${kak_opt_plug_install_dir:?}/.build/$plugin_name"
         domain_file="$build_dir/domain"
 
@@ -192,14 +191,15 @@ plug_install () {
             # processes. We need this because dash shell has this long
             # term bug:
             # https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=482999
+            jobs=$(mktemp "${TMPDIR:-/tmp}"/plug.kak.jobs.XXXXXX)
             jobs > "${jobs}"; active=$(wc -l < "${jobs}")
             while [ "${active}" -ge "${kak_opt_plug_max_active_downloads:?}" ]; do
                 sleep 1
                 jobs > "${jobs}"; active=$(wc -l < "${jobs}")
             done
+            rm -rf "${jobs}"
         done
         wait
-        rm -rf "${jobs}"
     ) > /dev/null 2>&1 < /dev/null &
 }
 
@@ -222,7 +222,6 @@ plug_update () {
     (
         plugin="${1%%.git}"
         plugin_name="${plugin##*/}"
-        jobs=$(mktemp "${TMPDIR:-/tmp}"/jobs.XXXXXX)
 
         # shellcheck disable=SC2030,SC2031
         [ -z "${GIT_TERMINAL_PROMPT}" ] && export GIT_TERMINAL_PROMPT=0
@@ -259,6 +258,7 @@ plug_update () {
                     fi
                 ) > /dev/null 2>&1 < /dev/null &
             fi
+            jobs=$(mktemp "${TMPDIR:-/tmp}"/jobs.XXXXXX)
             jobs > "${jobs}"; active=$(wc -l < "${jobs}")
             # TODO: re-check this
             # For some reason I need to multiply the amount of jobs by five here.
@@ -266,8 +266,8 @@ plug_update () {
                 sleep 1
                 jobs > "${jobs}"; active=$(wc -l < "${jobs}")
             done
+            rm -rf "${jobs}"
         done
-        rm -rf "${jobs}"
         wait
     ) > /dev/null 2>&1 < /dev/null &
 


### PR DESCRIPTION
`plug.kak` leaves behind a `/tmp/plug.kak.jobs*` file in some scenarios. Maybe because one of the functions creates it but exits early. For example in my [`mru-files.kak` test branch](https://gitlab.com/kstr0k/mru-files.kak/-/tree/test), test [`t/mru-files/all.t`](https://gitlab.com/kstr0k/mru-files.kak/-/blob/test/t/mru-files/all.t) reproduces every time.

In any case, this PR makes the `mktemp` and `rm -rf` calls "hug" the code that needs the jobs file. AFAICT it should have a positive performance impact, if any (no `mktemp` subshell until needed).