### PR TITLE
Avoid gnuisms

### DIFF
--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -212,7 +212,8 @@ plug_load() {
     conf_file="$build_dir/config"
 
     if [ -z "${noload}" ]; then
-        find -L "${path_to_plugin}" -path '*/.git' -prune -o -type f -name '*.kak' -exec printf 'source "%s"\n' {} \;
+        find -L "${path_to_plugin}" -path '*/.git' -prune -o -type f -name '*.kak' -print |
+            { while IFS= read -r _rl; do printf 'source "%s"\n' "$_rl"; done; }
     fi
     [ -e "$conf_file" ] && printf "%s\n" "source $conf_file"
     printf "%s\n" "set-option -add global plug_loaded_plugins %{${plugin} }"

--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -131,7 +131,7 @@ plug_install () {
         fi
 
         printf "%s\n" "evaluate-commands -client ${kak_client:-client0} %{ try %{ buffer *plug* } catch %{ plug-list noupdate } }" | kak -p "${kak_session}"
-        sleep 0.3
+        sleep 0.3 || sleep 1
 
         lockfile="${kak_opt_plug_install_dir}/.${plugin_name:-global}.plug.kak.lock"
         if [ -d "${lockfile}" ]; then
@@ -158,7 +158,7 @@ plug_install () {
                 } catch %{
                     execute-keys gjO${plugin}:<space>Not<space>installed<esc>
                 }}" | kak -p "${kak_session}"
-            sleep 0.2
+            sleep 0.2 || sleep 1
         else
             plugin_list=${kak_opt_plug_plugins}
         fi


### PR DESCRIPTION
The `find -printf` is more of a problem. I think I've also seen systems without `sleep 0.NNN` semi-recently, but in any case adding `|| sleep 1` can't hurt.