### PR TITLE
Shell fixes: initialize vars, avoid sed unless needed, etc

### DIFF
--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -48,8 +48,9 @@ plug () {
 require-module $module" ;;
                     (*)
                         shift
-                        case "$1" in (*'@'*)
-                            deferred=$(printf "%s\n" "$1" | sed "s/@/@@/g") ;;
+                        deferred=$1
+                        case "$deferred" in (*'@'*)
+                            deferred=$(printf "%s\n" "$deferred" | sed "s/@/@@/g") ;;
                         esac
                         printf "%s\n" "hook global ModuleLoaded '$module' %@ $deferred @"
                         [ "$demand" = "demand" ] && configurations="$configurations

--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -47,7 +47,10 @@ plug () {
                         [ "$demand" = "demand" ] && configurations="$configurations
 require-module $module" ;;
                     (*)
-                        shift; deferred=$(printf "%s\n" "$1" | sed "s/@/@@/g")
+                        shift
+                        case "$1" in (*'@'*)
+                            deferred=$(printf "%s\n" "$1" | sed "s/@/@@/g") ;;
+                        esac
                         printf "%s\n" "hook global ModuleLoaded '$module' %@ $deferred @"
                         [ "$demand" = "demand" ] && configurations="$configurations
 require-module $module" ;;

--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -20,6 +20,8 @@ plug () {
     hook_file="$build_dir/hooks"
     domain_file="$build_dir/domain"
 
+    configurations= hooks= domain= checkout= noload=
+
     case "${kak_opt_plug_loaded_plugins:-}" in
       (*"$plugin"*)
         printf "%s\n" "echo -markup %{{Information}$plugin_name already loaded}"

--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -34,13 +34,13 @@ plug () {
 
     while [ $# -gt 0 ]; do
         case $1 in
-            (branch|tag|commit) checkout_type=$1; shift; checkout="$1" ;;
+            (branch|tag|commit) checkout_type=$1; shift; checkout=${1?} ;;
             (noload) noload=1 ;;
-            (load-path) shift; eval "path_to_plugin=$1" ;;
+            (load-path) shift; eval "path_to_plugin=${1?}" ;;
             (defer|demand)
                 demand=$1
-                shift; module="$1"
-                case $2 in
+                shift; module=${1?}
+                case "${2:-}" in
                     (branch|tag|commit|noload|load-path|ensure|theme|domain|depth-sort|subset|no-depth-sort|config|defer|demand)
                     ;;
                     ("")
@@ -54,7 +54,7 @@ require-module $module" ;;
                 esac
                 ;;
             ("do") shift; hooks="$hooks
-$1" ;;
+${1?}" ;;
             (ensure) ensure=1 ;;
             (theme)
                 noload=1
@@ -62,13 +62,13 @@ $1" ;;
 find . -type f -name '*.kak' -exec ln -sf \"\$PWD/{}\" $kak_config/colors/ \;"
                 hooks="$hooks
 $theme_hooks" ;;
-            (domain) shift; domain="$1" ;;
+            (domain) shift; domain=${1?} ;;
             (depth-sort|subset)
                 printf "%s\n" "echo -debug %{Error: plug.kak: '$plugin_name': keyword '$1' is no longer supported. Use the module system instead}"
                 exit 1 ;;
             (no-depth-sort) printf "%s\n" "echo -debug %{Warning: plug.kak: '$plugin_name': use of deprecated '$1' keyword which has no effect}" ;;
             (config) shift; configurations="$configurations
-$1" ;;
+${1?}" ;;
             (*) configurations="$configurations
 $1" ;;
         esac


### PR DESCRIPTION
## Uninitialized vars

I've initialized some vars that `plug()` was using without initializing. I've had to subshell `plug()` invocations in `plug_many` because of these variables (and perhaps others, not yet discovered); but eventually I'd like to remove the subshell.

I've uncovered these with `set -u` &mdash; however I don't think the code is currently ready for `set -u`. There are a lot of places that rely on undefined vars. Some of them yield potentially undefined behavior.

For instance, did you **mean** to make the config block after demand/defer optional *unless followed by more args*? That's the current behavior, and I think it's not documented.

## sed / quoting

I've removed the call for `sed` unless the demand/defer block actually contains `@`. However, what do you think of using a literal esc character for quoting? `kak` supports it:
```
esc=$(printf \\e)  # actually, insert a real <esc> in editor
printf "%s\n" "hook global ModuleLoaded '$module' %$esc $deferred $esc"
```

## Profiling

I've also added `$EPOCHREALTIME` support for profiling (available in bash; busybox-static ash on Debian/Ubuntu, or custom builds). Speaking of which, since you asked how much of a difference it makes, try
```
# if on Debian / Ubuntu, just use /bin/busybox from busybox-static
bbdir=$(curl -s https://gitlab.com/kstr0k/f8ksh/-/raw/master/setup-bbox | sh)
ln -sf "$bbdir"/busybox ~/.config/kak/sh; echo "$bbdir"
KAKOUNE_POSIX_SHELL=~/.config/kak/sh kak
```
... (with `plug-many` or not). It makes a visible difference in startup time, and a logged difference with `set global plug_profile true
`