### PR TITLE
plug.sh: avoid mkdir if possible

### DIFF
--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -16,6 +16,7 @@ plug_code_append () {
 
 plug () {
     [ "${kak_opt_plug_profile:-}" = "true" ] && plug_save_timestamp profile_start
+    plugin_arg=$1
     plugin="${1%%.git}"; plugin=${plugin%%/}
     shift
     plugin_name="${plugin##*/}"
@@ -107,7 +108,7 @@ find . -type f -name '*.kak' -exec ln -sf \"\$PWD/{}\" $kak_config/colors/ \;"
     else
         if [ -n "$ensure" ] || [ "${kak_opt_plug_always_ensure:-}" = "true" ]; then
             (
-                plug_install "$plugin" "$noload"
+                plug_install "$plugin_arg" "$noload"
                 wait
                 if  [ "$kak_opt_plug_profile" = "true" ]; then
                     plug_save_timestamp profile_end
@@ -121,7 +122,7 @@ find . -type f -name '*.kak' -exec ln -sf \"\$PWD/{}\" $kak_config/colors/ \;"
 
 plug_install () {
     (
-        plugin="${1%%.git}"
+        plugin="${1%%.git}"; plugin=${plugin%%/}
         noload=$2
         plugin_name="${plugin##*/}"
         build_dir="${kak_opt_plug_install_dir:?}/.build/$plugin_name"

--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -80,8 +80,8 @@ find . -type f -name '*.kak' -exec ln -sf \"\$PWD/{}\" $kak_config/colors/ \;"
         shift
     done
 
-    rm -rf "$build_dir"
-    mkdir -p "$build_dir"
+    [ -d "$build_dir" ] || mkdir -p "$build_dir"
+    rm -rf "$build_dir"/* "$build_dir"/.[!.]* "$build_dir"/..?*
     [ -n "$configurations" ] && printf "%s" "$configurations" > "$conf_file"
     [ -n "$hooks" ] && printf "%s" "$hooks" > "$hook_file"
     [ -n "$domain" ] && printf "%s" "$domain" > "$domain_file"

--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -67,8 +67,7 @@ plug () {
             (ensure) ensure=1 ;;
             (theme)
                 noload=1
-                plug_code_append hooks "mkdir -p ${kak_config:?}/colors
-find . -type f -name '*.kak' -exec ln -sf \"\$PWD/{}\" $kak_config/colors/ \;"
+                plug_code_append hooks "[ -d \"${kak_config:?}/colors\" ] || mkdir -p \"${kak_config}/colors\"; ln -sf \"\$PWD\" \"$kak_config/colors\""
             ;;
             (domain) shift; domain=${1?} ;;
             (depth-sort|subset)


### PR DESCRIPTION
Possibly because it's one of the few remaining external calls, avoiding `mkdir` seems to make a surprisingly large difference. Comparing the commits (`gth` parameter below) for initial `plug-chain`, the dropped-subshells+fixes version, and the no-mkdir (this PR) version:

```
# cd /path/to/plug.kak
(K='KAK_PLUG_CHAIN={KKPC} /opt/kak/bin/kak -ui dummy -e quit';
hyperfine --export-markdown /tmp/hf-plug.md -w 2 -L gth 5828411,1852335,c264759 -L KKPC plug-chain -p 'git switch -d {gth}' "$K # {gth}")
```

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `KAK_PLUG_CHAIN=plug-chain /opt/kak/bin/kak -ui dummy -e quit # 1852335` | 281.3 ± 2.1 | 277.7 | 284.4 | 1.00 |
| `KAK_PLUG_CHAIN=plug-chain /opt/kak/bin/kak -ui dummy -e quit # 5828411` | 313.5 ± 2.4 | 309.4 | 316.1 | 1.11 ± 0.01 |
| `KAK_PLUG_CHAIN=plug-chain /opt/kak/bin/kak -ui dummy -e quit # c264759` | 339.8 ± 3.5 | 333.5 | 345.3 | 1.21 ± 0.02 |

i.e. 20% total (10% for each stage).

Have a look &mdash; I don't want to miss some bug again :)