### PR TITLE
Plug: comment clause

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,18 @@ The `config` keyword is optional, and can be skipped.
 Multiple `config` blocks are also supported.
 
 
+#### Commenting out `plug` options
+
+It may be tricky to "toggle" `plug` options, for debugging or testing purposes, because it is impossible to continue a command past a `#...` comment (also, `config` blocks usually span multiple lines).
+To solve this, `plug` supports a `comment` keyword that ignores its next argument.
+For example, to toggle a `load-path` option, wrap it in `comment %{}`; then remove the "wrapper" to turn it back on (without having to re-type the full path):
+```kak
+plug "andreyorst/fzf.kak" comment %{load-path /usr/local/src/fzf} config %{
+    # ...
+}
+```
+
+
 ### Deferring plugin configuration
 
 With the introduction of the module system, some configurations have to be preformed after loading the module.
@@ -326,6 +338,7 @@ plug-chain https://github.com/Delapouite/kakoune-select-view config %{
 ```
 
 Backslashes can also be used to separate individual `plug` "clauses" (which avoids the "visual hack" of empty config blocks, as above, serving as newlines).
+An initial `plug` redundant argument is also supported for symmetry.
 Either way, `plug-chain` simply figures out the parameters intended for each individual `plug` clause (using "`plug`" as a delimiter), and executes all implied `plug`s in a single shell call.
 All regular `plug` features are supported.
 Mix and match `plug` / `plug-chain` invocations in any order, any number of times.

--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -143,12 +143,10 @@ define-command -override plug-chain -params 0.. -docstring %{
             # reset "$@" on 1st iteration; args still in 'for'
             [ "$_plug_processed_args" != 0 ] || set --
             _plug_processed_args=$((_plug_processed_args + 1))
-            if [ plug = "$_plug_param" ]; then
-              break
-            fi
+            [ plug != "$_plug_param" ] || break
             set -- "$@" "$_plug_param"
           done
-          plug "$@"  # subshell would be safer, but slower
+          [ $# = 0 ] || plug "$@"  # subshell would be safer, but slower
         }
         while [ "$#" != 0 ]; do
           _plug_processed_args=0

--- a/rc/plug.kak
+++ b/rc/plug.kak
@@ -58,7 +58,7 @@ try %@
     require-module kak
 
     try %$
-        add-highlighter shared/kakrc/code/plug_keywords   regex '\b(plug|plug-chain|do|config|domain|defer|demand|load-path|branch|tag|commit)(?=[ \t])' 0:keyword
+        add-highlighter shared/kakrc/code/plug_keywords   regex '\b(plug|plug-chain|do|config|domain|defer|demand|load-path|branch|tag|commit|comment)(?=[ \t])' 0:keyword
         add-highlighter shared/kakrc/code/plug_attributes regex '(?<=[ \t])(noload|ensure|theme)\b' 0:attribute
         add-highlighter shared/kakrc/plug_post_hooks1     region -recurse '\{' '\bdo\K\h+%\{' '\}' ref sh
         add-highlighter shared/kakrc/plug_post_hooks2     region -recurse '\[' '\bdo\K\h+%\[' '\]' ref sh

--- a/rc/plug.sh
+++ b/rc/plug.sh
@@ -43,12 +43,13 @@ plug () {
             (branch|tag|commit) checkout_type=$1; shift; checkout=${1?} ;;
             (noload) noload=1 ;;
             (load-path) shift; eval "path_to_plugin=${1?}" ;;
+            (comment) shift ;;
             (defer|demand)
                 demand=$1
                 shift; module=${1?}
                 if [ $# -ge 2 ]; then
                     case "$2" in
-                        (branch|tag|commit|noload|load-path|ensure|theme|domain|depth-sort|subset|no-depth-sort|config|defer|demand)
+                        (branch|tag|commit|noload|load-path|ensure|theme|domain|depth-sort|subset|no-depth-sort|config|defer|demand|comment)
                         ;;
                         (*)
                             shift


### PR DESCRIPTION
This PR adds support for a `comment` clause, which ignores its next arg. This is quite useful when reconfiguring / debugging / testing (e.g. to disable / enable `load-path`, just wrap it in `comment %{load-path ... }`); but possibly also for documentation purposes.

There's also support for `plug-chain` accepting an initial `plug` parameter (actually, any empty plug clauses). This allows a more uniform grammar, which I think you've endorsed in our previous discussions:
```
plug-chain \
  plug URL1 ... \
  plug URL2 ... \
  # end plug-chain
```
